### PR TITLE
Document Linux build verification for 1.0.4

### DIFF
--- a/docs/LinuxBuildVerification.md
+++ b/docs/LinuxBuildVerification.md
@@ -1,0 +1,21 @@
+# Linux Build Verification for PosixError 1.0.4
+
+This document records the verification that PosixError version 1.0.4 can be
+built on Linux using the Swift Package Manager.
+
+## Procedure
+
+1. Fetched the upstream repository and checked out the `1.0.4` tag.
+2. Ran `swift build` on Ubuntu 22.04 with Swift 5.9.2 (the version available in
+   the execution environment).
+3. Confirmed that the build finished successfully without errors.
+
+## Output Summary
+
+```
+$ swift build
+Build complete!
+```
+
+The package compiled successfully, demonstrating that version 1.0.4 builds on
+Linux as expected.


### PR DESCRIPTION
## Summary
- add documentation that records verifying the 1.0.4 tag builds on Linux

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68dd934d767c83289e7de4cbeb4debdd